### PR TITLE
Feat/generate test data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,5 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+scripts/data/*

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
         "lint": "eslint .",
         "lint:fix": "eslint . --fix",
         "format": "prettier --write .",
-        "prettier": "prettier --write --config ./.prettierrc './src/**'"
+        "prettier": "prettier --write --config ./.prettierrc './src/**'",
+        "generate:user": "node ./scripts/generate-users-data.js",
+        "generate:word": "node ./scripts/generate-words-data.js"
     },
     "author": "",
     "license": "ISC",

--- a/scripts/generate-users-data.js
+++ b/scripts/generate-users-data.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+
+function generateRandomId() {
+    return Array(24)
+        .fill(0)
+        .map(() => Math.floor(Math.random() * 16).toString(16))
+        .join('');
+}
+
+function generateRandomNickname(index) {
+    return `user${index}`;
+}
+
+function generateUser(index) {
+    const now = new Date().toISOString();
+    return {
+        _id: { $oid: generateRandomId() },
+        deletedAt: null,
+        nickname: generateRandomNickname(index),
+        email: `user${index}@example.com`,
+        password: '$2b$10$NWhqlRrE5W0YMHlnaBi.CODbFjPZzvgT5G993eKoziVzrhH3M6KNC',
+        role: 'user',
+        snsId: null,
+        provider: null,
+        recentSearches: [],
+        requests: [],
+        createdAt: { $date: now },
+        updatedAt: { $date: now },
+        __v: 0,
+    };
+}
+
+function generateUsers(count) {
+    const users = [];
+    for (let i = 0; i < count; i++) {
+        users.push(generateUser(i));
+    }
+    return users;
+}
+
+async function generateAndSaveData(totalCount) {
+    const userData = generateUsers(totalCount);
+    const fileName = './data/test-users-data.json';
+    fs.writeFileSync(fileName, JSON.stringify(userData, null, 2));
+
+    console.log('✅ 10000개의 유저 데이터가 생성되었습니다.');
+    console.log('📁 파일 위치: users.json');
+}
+
+generateAndSaveData(10000).catch(console.error);

--- a/scripts/generate-users-data.js
+++ b/scripts/generate-users-data.js
@@ -40,7 +40,7 @@ function generateUsers(count) {
 
 async function generateAndSaveData(totalCount) {
     const userData = generateUsers(totalCount);
-    const fileName = './data/test-users-data.json';
+    const fileName = './scripts/data/test-users-data.json';
     fs.writeFileSync(fileName, JSON.stringify(userData, null, 2));
 
     console.log('✅ 10000개의 유저 데이터가 생성되었습니다.');

--- a/scripts/generate-words-data.js
+++ b/scripts/generate-words-data.js
@@ -33,7 +33,7 @@ function* generateWordBatch(totalCount, batchSize = 1000) {
 
 async function generateAndSaveData(totalCount) {
     console.time('Data Generation');
-    const fileName = './data/test-words-data.json';
+    const fileName = './scripts/data/test-words-data.json';
     const batchSize = 1000;
     let currentBatch = 1;
     const totalBatches = Math.ceil(totalCount / batchSize);

--- a/scripts/generate-words-data.js
+++ b/scripts/generate-words-data.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+
+const prefixes = ['A', 'Ab', 'Ac', 'Ad', 'Af', 'Ag', 'Al', 'Am', 'An', 'Ap', 'Ar', 'As', 'At', 'Au'];
+const middles = ['sync', 'pi', 'data', 'net', 'web', 'cloud', 'tech', 'dev', 'sys', 'log'];
+const suffixes = ['Service', 'API', 'Hub', 'Lab', 'Flow', 'Base', 'Core', 'Plus', 'Pro', 'Box'];
+
+function generateRandomWord(index) {
+    const prefix = prefixes[Math.floor(Math.random() * prefixes.length)];
+    const middle = middles[Math.floor(Math.random() * middles.length)];
+    const suffix = suffixes[Math.floor(Math.random() * suffixes.length)];
+    return `${prefix}${middle}${suffix}${index}`;
+}
+
+function* generateWordBatch(totalCount, batchSize = 1000) {
+    for (let i = 0; i < totalCount; i += batchSize) {
+        const batch = [];
+        const currentBatchSize = Math.min(batchSize, totalCount - i);
+
+        for (let j = 0; j < currentBatchSize; j++) {
+            const word = generateRandomWord(i + j);
+            batch.push({
+                word,
+                awkPron: `어색한_${word}`,
+                comPron: `일반적인_${word}`,
+                info: `${word}에 대한 설명입니다. (테스트 데이터 ${i + j + 1})`,
+                suggestedBy: 'admin',
+                freq: Math.floor(Math.random() * 100),
+            });
+        }
+        yield batch;
+    }
+}
+
+async function generateAndSaveData(totalCount) {
+    console.time('Data Generation');
+    const fileName = './data/test-words-data.json';
+    const batchSize = 1000;
+    let currentBatch = 1;
+    const totalBatches = Math.ceil(totalCount / batchSize);
+
+    fs.writeFileSync(fileName, '[\n', 'utf8');
+
+    for (const batch of generateWordBatch(totalCount, batchSize)) {
+        console.log(`처리 중: ${currentBatch}/${totalBatches} 배치`);
+
+        const batchData = batch.map((item) => JSON.stringify(item)).join(',\n');
+        fs.appendFileSync(fileName, currentBatch === 1 ? batchData : ',\n' + batchData, 'utf8');
+
+        currentBatch++;
+    }
+
+    fs.appendFileSync(fileName, '\n]', 'utf8');
+
+    console.log(`✅ ${totalCount}개의 테스트 데이터 생성 완료!`);
+    console.log(`📁 파일 위치: ${fileName}`);
+}
+
+generateAndSaveData(100000).catch(console.error);


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
테스트 단어 데이터 100,000개와 유저 데이터 10,000개를 JSON 파일로 생성하는 스크립트를 추가하였습니다.
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

-   ✨ 유저 데이터 생성 스크립트 추가
-   ✨ 단어 데이터 생성 스크립트 추가

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

-   closed #101 

## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 -->
사용법

- 유저 JSON 파일 생성 : `npm run generate:user`
- 단어 JSON 파일 생성 : `npm run generate:word`

/scripts/data/ 하위에 추가된 json파일을 MongoDB Compass를 통해 삽입
